### PR TITLE
make content width max-out at 80ch

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -8,7 +8,7 @@ body {
   }
   max-width: 80ch;
   margin: 0 auto;
-  padding: 2em 2em;
+  padding: 2rem 2rem;
   a {
     color: inherit;
     transition: 100ms ease-in-out color;


### PR DESCRIPTION
increases readability on wider screens due to sane line-lengths rather than trailing on for 1800px